### PR TITLE
Fix docs for src directory

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,6 +5,7 @@ This folder contains source components that power the Veteran Analytics platform
 ## Structure:
 - `/gpt-actions/`: Custom GPT action definitions and OpenAPI specs
 - `/data-loaders/`: Scripts or logic to ingest and prepare structured datasets
-- `/scripts/`: Utility scripts, prompt tools, transformers, etc.
+
+Utility scripts and helper tools live in the repository's top-level `/scripts/` directory.
 
 Each subfolder includes its own README and version-controlled content.

--- a/src/gpt-actions/README.md
+++ b/src/gpt-actions/README.md
@@ -3,9 +3,8 @@
 This folder contains OpenAPI specifications and schema files for GPT-based actions that support the Veteran Analytics platform.
 
 ## Contents:
-- `openapi-spec.json`: Main OpenAPI spec for action definitions
-- `veteran-data-actions.yaml`: Actions related to veteran datasets and cohort insights
-- `policy-ref-lookup.json`: Legal and procedural reference tools
-- `README.md`: Folder index
+- `README.md`: Folder index and overview
+
+Additional OpenAPI specifications will be added here as the project evolves.
 
 Each file defines callable tools designed to work with natural language interfaces, structured data, and VA-specific domain logic.


### PR DESCRIPTION
## Summary
- remove incorrect scripts entry from src/README
- tidy gpt-actions README contents section

## Testing
- `pylint scripts/restructure_vista_backend.py | head`

------
https://chatgpt.com/codex/tasks/task_e_6854ccad0808832a9df8e3be25652552