### PR TITLE
Move env load script to tests and add pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,18 @@ This project uses a modern, scalable technology stack:
 
 The primary component of this project is the **VISTA API Backend**. For detailed instructions on how to set up the development environment, run the data processing scripts, and launch the API, please see the dedicated README file:
 
+
 ➡️ **[VISTA API Backend README](https://www.google.com/search?q=src/vista-api-backend/README.md)**
+
+### 🧪 Running Tests
+
+Install the required packages using `requirements.txt` and run the automated
+tests with [pytest](https://docs.pytest.org/):
+
+```bash
+pip install -r requirements.txt pytest
+pytest
+```
 
 -----
 

--- a/scripts/test_env_load.py
+++ b/scripts/test_env_load.py
@@ -1,7 +1,0 @@
-from dotenv import load_dotenv
-import os
-
-load_dotenv()
-
-key_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
-print("Loaded credential path:", key_path)

--- a/tests/test_env_load.py
+++ b/tests/test_env_load.py
@@ -1,0 +1,8 @@
+import os
+from dotenv import load_dotenv
+
+
+def test_env_variable_loaded():
+    """Ensure GOOGLE_APPLICATION_CREDENTIALS from .env is loaded."""
+    load_dotenv()
+    assert os.getenv("GOOGLE_APPLICATION_CREDENTIALS") is not None


### PR DESCRIPTION
## Summary
- relocate the environment load script into the `tests` folder
- convert the script into a pytest
- add instructions for running pytest in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ccbcf0ec832a899e23352450eb70