### PR TITLE
Fix docs for script path and gpt-actions contents

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,6 @@ This folder contains source components that power the Veteran Analytics platform
 - `/gpt-actions/`: Custom GPT action definitions and OpenAPI specs
 - `/data-loaders/`: Scripts or logic to ingest and prepare structured datasets
 
-Utility scripts and helper tools live in the repository's top-level `/scripts/` directory.
+- `../scripts/`: Utility helper scripts stored at the repository root
 
 Each subfolder includes its own README and version-controlled content.

--- a/src/gpt-actions/README.md
+++ b/src/gpt-actions/README.md
@@ -2,9 +2,9 @@
 
 This folder contains OpenAPI specifications and schema files for GPT-based actions that support the Veteran Analytics platform.
 
-## Contents:
-- `README.md`: Folder index and overview
+## Contents
 
-Additional OpenAPI specifications will be added here as the project evolves.
+Currently this folder only contains this `README.md` file. Additional OpenAPI
+specifications and schemas will be added as the project evolves.
 
 Each file defines callable tools designed to work with natural language interfaces, structured data, and VA-specific domain logic.


### PR DESCRIPTION
## Summary
- clarify location of helper scripts in `src/README.md`
- update contents description for `src/gpt-actions/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d5a3d9c4832aafcbea07e5d43587