### PR TITLE
Add Cloudflare URL note and config

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 GOOGLE_APPLICATION_CREDENTIALS=C:/VISTA_Credentials/vista-api-backend-6578a1a1c769.json
 SOURCE_XLS_FOLDER=data/XLS_TO_PROCESS
 MARKDOWN_OUTPUT_FOLDER=C:/VISTA_Repository/ABR Excel Table Markdowns
+API_BASE_URL=https://letter-mario-lexington-sunny.trycloudflare.com
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ pip install -r requirements.txt pytest
 pytest
 ```
 
+### Configuration
+
+The API's public URL is exposed through a Cloudflare Tunnel. This URL changes
+whenever you start a new tunnel. Set the `API_BASE_URL` environment variable (or
+edit `.env`) to your current Cloudflare URL and update `openapi_spec.yaml`
+accordingly whenever a new tunnel is created.
+
 -----
 
 ### 📖 Documentation

--- a/openapi_spec.yaml
+++ b/openapi_spec.yaml
@@ -6,6 +6,9 @@ info:
 servers:
   # This is the public URL that Cloudflare Tunnel provided.
   # KEEP BOTH YOUR FLASK APP AND CLOUDFLARE TUNNEL TERMINALS OPEN AND RUNNING.
+  # NOTE: This trycloudflare.com URL is temporary and will change each time you
+  # start a new tunnel. Update this value whenever you create a new Cloudflare
+  # tunnel.
   - url: https://letter-mario-lexington-sunny.trycloudflare.com
     description: Public URL via Cloudflare Tunnel
 paths:


### PR DESCRIPTION
## Summary
- clarify temporary nature of the Cloudflare tunnel URL
- document API_BASE_URL environment variable
- include the variable in `.env`

## Testing
- `pytest -q` *(fails: ImportError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856668a2030832a9830b4b9ecf21c19