### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This project uses a modern, scalable technology stack:
 The primary component of this project is the **VISTA API Backend**. For detailed instructions on how to set up the development environment, run the data processing scripts, and launch the API, please see the dedicated README file:
 
 
-➡️ **[VISTA API Backend README](https://www.google.com/search?q=src/vista-api-backend/README.md)**
+➡️ **[VISTA API Backend README](src/vista-api-backend/README.md)**
 
 ### 🧪 Running Tests
 
@@ -75,13 +75,13 @@ pytest
 
 For a deeper dive into the project's architecture, goals, and technical implementation, please refer to our documentation.
 
-  * **[Project Overview](https://www.google.com/search?q=docs/project-overview.md)**: A high-level summary of the project.
-  * **[VISTA Codex (Knowledge Base)](https://www.google.com/search?q=docs/vista_gem_codex.md)**: The technical specifications and project memory for the VISTA system.
+  * **[Project Overview](docs/project-overview.md)**: A high-level summary of the project.
+  * **[VISTA Codex (Knowledge Base)](docs/vista_gem_codex.md)**: The technical specifications and project memory for the VISTA system.
 
 ---
 ### 📘 DAILY LOG – VISTA DEVELOPMENT
 
-➡️ [Click here for the full daily development log](https://github.com/MarcArmy2003/veteran-analytics/blob/main/docs/daily_log.md)
+➡️ [Click here for the full daily development log](docs/daily_log.md)
 
 Includes detailed progress tracking, session notes, environment changes, file migrations, and system debugging activities.
 
@@ -89,5 +89,5 @@ Includes detailed progress tracking, session notes, environment changes, file mi
 
 ### ⚖️ Legal
 
-  * **[Terms of Use](https://www.google.com/search?q=legal/TERMS.md)**
-  * **[Trademark Policy](https://www.google.com/search?q=legal/TRADEMARK.md)**
+  * **[Terms of Use](legal/TERMS.md)**
+  * **[Trademark Policy](legal/TRADEMARK.md)**

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -56,7 +56,7 @@ This project uses a modern, scalable technology stack:
 
 The primary component of this project is the **VISTA API Backend**. For detailed instructions on how to set up the development environment, run the data processing scripts, and launch the API, please see the dedicated README file:
 
-➡️ **[VISTA API Backend README](https://www.google.com/search?q=src/vista-api-backend/README.md)**
+➡️ **[VISTA API Backend README](../src/vista-api-backend/README.md)**
 
 -----
 
@@ -64,12 +64,12 @@ The primary component of this project is the **VISTA API Backend**. For detailed
 
 For a deeper dive into the project's architecture, goals, and technical implementation, please refer to our documentation.
 
-  * **[Project Overview](https://www.google.com/search?q=docs/project-overview.md)**: A high-level summary of the project.
-  * **[VISTA Codex (Knowledge Base)](https://www.google.com/search?q=docs/vista_gem_codex.md)**: The technical specifications and project memory for the VISTA system.
+  * **[Project Overview](project-overview.md)**: A high-level summary of the project.
+  * **[VISTA Codex (Knowledge Base)](vista_gem_codex.md)**: The technical specifications and project memory for the VISTA system.
 
 -----
 
 ### ⚖️ Legal
 
-  * **[Terms of Use](https://www.google.com/search?q=legal/TERMS.md)**
-  * **[Trademark Policy](https://www.google.com/search?q=legal/TRADEMARK.md)**
+  * **[Terms of Use](../legal/TERMS.md)**
+  * **[Trademark Policy](../legal/TRADEMARK.md)**


### PR DESCRIPTION
## Summary
- fix README links to use repo paths instead of Google searches
- update docs/readme.md links similarly

## Testing
- `pytest -q` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68566685f660832aa8bc64ea53e87881