### PR TITLE
Update gitignore with Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
-
 # Google Cloud Service Account Keys
 misfit/vista-api-backend-6578a1a1c769.json
 specs/vista-api-backend-6578a1a1c769.json
-specs/vista-api-backend-6578a1a1c769.json
-misfit/vista-api-backend-6578a1a1c769.json
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyd
+*.so
+*.dll
+*.lib
+


### PR DESCRIPTION
## Summary
- deduplicate service account JSON paths in `.gitignore`
- ignore Python cache files and binary artifacts

## Testing
- `pytest -q` *(fails: ImportError attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68566681a430832a88521a49551df47c