### PR TITLE
Fix pylint workflow path

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -24,11 +24,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pylint
-        # The following line assumes all your runtime dependencies are in 'src/vista-api-backend'
-        # Adjust the path if your requirements.txt is elsewhere.
-        if [ -f src/vista-api-backend/requirements.txt ]; then pip install -r src/vista-api-backend/requirements.txt; fi
+        # Install runtime requirements if present
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Analysing the code with pylint
-      # Adjust the path to lint all relevant Python files.
-      # The command below targets the 'app' directory inside 'src/vista-api-backend'.
+      # Lint all Python files tracked in the repository.
       run: |
-        pylint $(find src/vista-api-backend/app -name "*.py")
+        pylint $(git ls-files '*.py')


### PR DESCRIPTION
## Summary
- update Github Actions workflow
- lint all python files in repo
- fix dependency step path

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6857123301b4832aab390f10e39ab80c