### PR TITLE
Add Dockerfile.chunker for script execution

### DIFF
--- a/Dockerfile.chunker
+++ b/Dockerfile.chunker
@@ -1,0 +1,20 @@
+# Use Python 3.11 base image
+FROM python:3.11-slim-buster
+
+# Set working directory
+WORKDIR /app
+
+# Copy files
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy rest of the code
+COPY . .
+
+# Set environment variables if needed
+ENV XLS_INPUT_FOLDER=gs://vista-api-backend-rag-files
+ENV TXT_OUTPUT_FOLDER=gs://vista-processed-markdowns
+
+# Run the chunker script
+CMD ["python", "scripts/definitive_chunker.py"]
+

--- a/scripts/definitive_chunker.py
+++ b/scripts/definitive_chunker.py
@@ -3,8 +3,8 @@ import os
 import pandas as pd
 import glob
 
-SOURCE_XLS_FOLDER = "XLS_TO_PROCESS"
-MARKDOWN_OUTPUT_FOLDER = "VISTA_Repository/ABR Excel Table Markdowns"
+SOURCE_XLS_FOLDER = os.getenv("XLS_INPUT_FOLDER", "XLS_TO_PROCESS")
+MARKDOWN_OUTPUT_FOLDER = os.getenv("TXT_OUTPUT_FOLDER", "VISTA_Repository/ABR Excel Table Markdowns")
 # This is now a hard limit in bytes. 2MB to be safe.
 MAX_BYTES = 2000000  
 


### PR DESCRIPTION
## Summary
- add Dockerfile.chunker to run definitive_chunker.py directly
- allow environment variables to override input/output folders

## Testing
- `python -m py_compile scripts/definitive_chunker.py`
- `pytest tests/test_deprecate_kwarg.py::test_deprecate_kwarg -q`

------
https://chatgpt.com/codex/tasks/task_e_685a41e41fbc832aa7e44c7d60468c34